### PR TITLE
[TH2-5161] Fixed: `PicoOperator` copies default `cradle_manager.json`…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Local Run (1.5.1)
+### Local Run (1.5.2)
 1. clone pico-operator repo
 2. build code using `gradle build` command
 3. run with `"-Dconverter.config=./path/to/pico-operator-config"`
@@ -51,6 +51,10 @@ defaultSchemaConfigs:
 ```
 
 # Release notes
+
+## 1.5.2
+### Fix:
++ `PicoOperator` copies default `cradle_manager.json` config instead of generated
 
 ## 1.5.1
 ### Refactored:

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 
 kotlin.code.style=official
 
-release_version=1.5.1
+release_version=1.5.2
 
 kotlin_version=1.8.22
 kotlin_detekt_version=1.23.1

--- a/src/main/kotlin/com/exactpro/th2/pico/operator/PicoOperator.kt
+++ b/src/main/kotlin/com/exactpro/th2/pico/operator/PicoOperator.kt
@@ -43,7 +43,6 @@ class PicoOperator(
         when (val mode = config.mode) {
             "full" -> {
                 ConfigHandler.clearOldConfigs(appConfig.generatedConfigsLocation)
-                ConfigHandler.copyDefaultConfigs(appConfig.defaultSchemaConfigs, appConfig.generatedConfigsLocation)
                 rabbitMQManager.creteInitialSetup()
 
                 val queuesProcessor = QueuesProcessor(rabbitMQManager).also {
@@ -54,6 +53,7 @@ class PicoOperator(
                     imageExtractor.process(it)
                     queuesProcessor.process(it)
                 }
+                ConfigHandler.copyDefaultConfigs(appConfig.defaultSchemaConfigs, appConfig.generatedConfigsLocation)
                 imageExtractor.saveImagesToFile()
                 queuesProcessor.removeUnusedQueues()
                 rabbitMQManager.closeChannel()
@@ -71,11 +71,11 @@ class PicoOperator(
             }
             "configs" -> {
                 ConfigHandler.clearOldConfigs(appConfig.generatedConfigsLocation)
-                ConfigHandler.copyDefaultConfigs(appConfig.defaultSchemaConfigs, appConfig.generatedConfigsLocation)
                 boxResources.values.forEach {
                     ConfigProcessor(infraMgrConfig, it, config.isOldFormat, appConfig, repositoryLoader).process()
                     imageExtractor.process(it)
                 }
+                ConfigHandler.copyDefaultConfigs(appConfig.defaultSchemaConfigs, appConfig.generatedConfigsLocation)
                 imageExtractor.saveImagesToFile()
             }
             else -> {

--- a/src/main/kotlin/com/exactpro/th2/pico/operator/PicoOperator.kt
+++ b/src/main/kotlin/com/exactpro/th2/pico/operator/PicoOperator.kt
@@ -43,6 +43,7 @@ class PicoOperator(
         when (val mode = config.mode) {
             "full" -> {
                 ConfigHandler.clearOldConfigs(appConfig.generatedConfigsLocation)
+                ConfigHandler.copyDefaultConfigs(appConfig.defaultSchemaConfigs, appConfig.generatedConfigsLocation)
                 rabbitMQManager.creteInitialSetup()
 
                 val queuesProcessor = QueuesProcessor(rabbitMQManager).also {
@@ -53,7 +54,6 @@ class PicoOperator(
                     imageExtractor.process(it)
                     queuesProcessor.process(it)
                 }
-                ConfigHandler.copyDefaultConfigs(appConfig.defaultSchemaConfigs, appConfig.generatedConfigsLocation)
                 imageExtractor.saveImagesToFile()
                 queuesProcessor.removeUnusedQueues()
                 rabbitMQManager.closeChannel()
@@ -71,11 +71,11 @@ class PicoOperator(
             }
             "configs" -> {
                 ConfigHandler.clearOldConfigs(appConfig.generatedConfigsLocation)
+                ConfigHandler.copyDefaultConfigs(appConfig.defaultSchemaConfigs, appConfig.generatedConfigsLocation)
                 boxResources.values.forEach {
                     ConfigProcessor(infraMgrConfig, it, config.isOldFormat, appConfig, repositoryLoader).process()
                     imageExtractor.process(it)
                 }
-                ConfigHandler.copyDefaultConfigs(appConfig.defaultSchemaConfigs, appConfig.generatedConfigsLocation)
                 imageExtractor.saveImagesToFile()
             }
             else -> {

--- a/src/main/kotlin/com/exactpro/th2/pico/operator/generator/ConfigHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/pico/operator/generator/ConfigHandler.kt
@@ -31,6 +31,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.inputStream
 import kotlin.io.path.isDirectory
 import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.notExists
 import kotlin.io.path.outputStream
 
 abstract class ConfigHandler(
@@ -86,10 +87,12 @@ abstract class ConfigHandler(
                 .filter(Path::isDirectory)
                 .forEach { dir ->
                     schemaConfigs.configNames.values.forEach { file ->
-                        val source = schemaConfigs.location.resolve(file)
                         val target = dir.resolve(file)
-                        source.copyTo(target, overwrite = true)
-                        LOGGER.debug { "Updated '$target' from '$source' file" }
+                        if (target.notExists()) {
+                            val source = schemaConfigs.location.resolve(file)
+                            source.copyTo(target, overwrite = false)
+                            LOGGER.debug { "Updated '$target' from '$source' file" }
+                        }
                     }
                 }
         }


### PR DESCRIPTION
… config instead of generated